### PR TITLE
Fix duplicate prefixes being added

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,14 +59,16 @@ const jiraTag = process.argv[2];
 const tagMatcher = new RegExp(`^${jiraTag}-\\d+`, "i");
 const commitMsgFile = process.env.GIT_PARAMS;
 const commitMsg = fs.readFileSync(commitMsgFile, { encoding: "utf-8" });
-const commitMsgTitle = commitMsg.split("\n")[0];
 const branchName = getBranchName();
 const issueTag = getIssueTagFromBranchName(branchName);
+const rawCommitMsgTitle = commitMsg.split("\n")[0];
 
-if (issueTag && isInvalidMessage(commitMsgTitle)) {
+if (issueTag && isInvalidMessage(rawCommitMsgTitle)) {
     // Add the JIRA issue tag to commit message title
+    const ticketTag = issueTag.toUpperCase();
+    const commitMsgTitle = rawCommitMsgTitle.replace(ticketTag, "").trim();
     const messageLines = commitMsg.split("\n");
-    messageLines[0] = `${issueTag.toUpperCase()} ${commitMsgTitle}`;
+    messageLines[0] = `${ticketTag} ${commitMsgTitle}`;
     fs.writeFileSync(commitMsgFile, messageLines.join("\n"), { encoding: "utf-8" });
 } else {
     fs.writeFileSync(commitMsgFile, commitMsg, { encoding: "utf-8" });

--- a/index.spec.js
+++ b/index.spec.js
@@ -10,6 +10,12 @@ describe('index.js', () => {
         expect(executeScriptMock("TAG", "TAG-5032-add-readme", "Add readme to project")).to.equal("TAG-5032 Add readme to project");
     });
 
+    it('should not add a prefix again to my already prefixed commit message', () => {
+        expect(executeScriptMock("SPAN", "SPAN-1-proof-of-concept", "SPAN-1 Initial commit✨")).to.equal("SPAN-1 Initial commit✨");
+        expect(executeScriptMock("PROJECT", "PROJECT-3-githook-test", "PROJECT-3 Add support for githooks")).to.equal("PROJECT-3 Add support for githooks");
+        expect(executeScriptMock("TAG", "TAG-5032-add-readme", "TAG-5032 Add readme to project")).to.equal("TAG-5032 Add readme to project");
+    });
+
     it('should not add a prefix in merge pull requests', () => {
         const commitMergeMessage = "Merge branch 'develop' of github.com:jessedobbelaere/jira-smart-commit into bugfixes";
         expect(executeScriptMock("SPAN", "SPAN-1-proof-of-concept", commitMergeMessage)).to.equal(commitMergeMessage);

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "jira-smart-commit",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A githook script that transforms commit messages to JIRA smart commits based on branch names",
   "author": "Jesse Dobbelaere <jesse@dobbelae.re>",
   "license": "MIT",
   "main": "index.js",
   "scripts": {
-    "test": "mocha index.test",
+    "test": "mocha index.spec.js",
     "release": "with-package git commit -am pkg.version && with-package git tag pkg.version && git push && npm publish && git push --tags"
   },
   "engines": {


### PR DESCRIPTION
When you had a commit message "JIRA-01 This is my message" and you git commit --amend to it, it would add the Jira ticket tag again and again. 