### PR TITLE
make more flaxible to catch task name & use HUSKY_GIT_PARAMS if GIT_P…

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,20 @@ A Node.js git hook script to prefix commits automatically with the JIRA ticket, 
     ```
 3. Configure scripts in `package.json`. The script expects his first argument to be the JIRA tag of the project.
     ```
-    "commitmsg": "jira-smart-commit SPAN"
+    "commit-msg": "jira-smart-commit SPAN"
     ```
+    or environment variables 
+      
+      - TAG_MATCHER - regular expression
+      - TAG_MATCH_INDEX - match index
+      - DEBUG - if true will console log some data about branch, matches array etc
+      
+    example: if your branches have feature/SPAN-1234/some-description template
+    ```
+    "commit-msg": "TAG_MATCHER=\"^[^/]+/(SPAN-[0-9]+)\" TAG_MATCH_INDEX=1 jira-smart-commit"
+    ```
+    
+    
 4. Do your git commits like usual. If the branch was prefixed with a JIRA tag, your commit message will get prefixed with
 the same tag.
 

--- a/index.spec.js
+++ b/index.spec.js
@@ -8,6 +8,14 @@ describe('index.js', () => {
         expect(executeScriptMock("SPAN", "SPAN-1-proof-of-concept", "Initial commit✨")).to.equal("SPAN-1 Initial commit✨");
         expect(executeScriptMock("PROJECT", "PROJECT-3-githook-test", "Add support for githooks")).to.equal("PROJECT-3 Add support for githooks");
         expect(executeScriptMock("TAG", "TAG-5032-add-readme", "Add readme to project")).to.equal("TAG-5032 Add readme to project");
+
+        process.env.TAG_MATCHER = "^[^/]+/(SPAN-[0-9]+)";
+        process.env.TAG_MATCH_INDEX = "1";
+        process.env.DEBUG = "true";
+        expect(executeScriptMock(undefined, "feature/SPAN-1234/init", "Initial commit")).to.equal('SPAN-1234 Initial commit');
+        delete process.env.TAG_MATCHER;
+        delete process.env.TAG_MATCH_INDEX;
+        delete process.env.DEBUG;
     });
 
     it('should not add a prefix again to my already prefixed commit message', () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jira-smart-commit",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A githook script that transforms commit messages to JIRA smart commits based on branch names",
   "author": "Jesse Dobbelaere <jesse@dobbelae.re>",
   "license": "MIT",


### PR DESCRIPTION
 - have add environment variables 
      
      - TAG_MATCHER - regular expression
      - TAG_MATCH_INDEX - match index
      - DEBUG - if true will console log some data about branch, matches array etc

new it is possible to have any template for branches, no any changes required for previous installations
 
- update husky syntax, add HUSKY_GIT_PARAMS support